### PR TITLE
Fixed NOCRYPTO mode, which is really "no entropy mode" for debugging.…

### DIFF
--- a/donut.c
+++ b/donut.c
@@ -556,10 +556,16 @@ static int CreateModule(PDONUT_CONFIG c, file_info *fi) {
     {
       // If no domain name specified, generate a random one
       if(c->domain[0] == 0) {
+#ifndef NOCRYPTO
         if(!GenRandomString(c->domain, DONUT_DOMAIN_LEN)) {
           err = DONUT_ERROR_RANDOM;
           goto cleanup;
         }
+#else
+    memset(c->domain, DONUT_DOMAIN_LEN-1, 0x90);
+    c->domain[DONUT_DOMAIN_LEN] = 0x00;
+#endif
+
       }
       // convert to unicode format.
       // wchar_t is 32-bits on linux, but 16-bit on windows. :-|
@@ -678,12 +684,16 @@ static int CreateInstance(PDONUT_CONFIG c, file_info *fi) {
     if(!GenRandomString(inst->sig, DONUT_SIG_LEN)) {
       return DONUT_ERROR_RANDOM;
     }
-#endif
-   
     DPRINT("Generating random IV for Maru hash");
     if(!CreateRandom(&inst->iv, MARU_IV_LEN)) {
       return DONUT_ERROR_RANDOM;
     }
+#else
+   memset(&inst->key, 0, sizeof(DONUT_CRYPT));
+   memset(&inst->mod_key, 0, sizeof(DONUT_CRYPT));
+   memset(&inst->sig, 0, sizeof(DONUT_SIG_LEN));
+   memset(&inst->iv, 0, sizeof(MARU_IV_LEN));
+#endif
     
     DPRINT("Generating hashes for API using IV: %" PRIx64, inst->iv);
     

--- a/include/donut.h
+++ b/include/donut.h
@@ -71,10 +71,8 @@
 
 #endif
 
-#if !defined(NOCRYPTO)
 #include "hash.h"        // api hashing
 #include "encrypt.h"     // symmetric encryption of instance+module
-#endif
 
 #if !defined(WINDOWS)
 #define strnicmp(x,y,z) strncasecmp(x,y,z)


### PR DESCRIPTION
…  The goal is to have donut generate exactly the same file every time in NOCRYPTO mode so we can test and debug ports to other languages.

Changes:
- Fixed includes so NOCRYPTO builds
- Made all keys and IVs zero when NOCRYPTO
- Made the random domain all AAAAA when NOCRYPTO