### PR TITLE
Always close handle returned from CreateFileMapping()

### DIFF
--- a/include/mmap-windows.c
+++ b/include/mmap-windows.c
@@ -58,16 +58,15 @@ void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset
 		dwDesiredAccess |= FILE_MAP_COPY;
 	void *ret = MapViewOfFile(h, dwDesiredAccess, DWORD_HI(offset), DWORD_LO(offset), length);
 	if (ret == NULL) {
-		CloseHandle(h);
 		ret = MAP_FAILED;
 	}
+	CloseHandle(h);
 	return ret;
 }
 
 void munmap(void *addr, size_t length)
 {
 	UnmapViewOfFile(addr);
-	/* ruh-ro, we leaked handle from CreateFileMapping() ... */
 }
 
 #undef DWORD_HI

--- a/loader/exe2h/mmap-windows.c
+++ b/loader/exe2h/mmap-windows.c
@@ -58,16 +58,15 @@ void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset
 		dwDesiredAccess |= FILE_MAP_COPY;
 	void *ret = MapViewOfFile(h, dwDesiredAccess, DWORD_HI(offset), DWORD_LO(offset), length);
 	if (ret == NULL) {
-		CloseHandle(h);
 		ret = MAP_FAILED;
 	}
+	CloseHandle(h);
 	return ret;
 }
 
 void munmap(void *addr, size_t length)
 {
 	UnmapViewOfFile(addr);
-	/* ruh-ro, we leaked handle from CreateFileMapping() ... */
 }
 
 #undef DWORD_HI


### PR DESCRIPTION
Hi. When using donut as a library, I noticed that the input file is locked even after calling `DonutDelete`.
The problem is that the handle returned from `CreateFileMapping()` is never closed.

Closing the handle can be done safely after call to `MapViewOfFile` because the returned object holds an internal reference to the file mapping.

https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createfilemappinga#remarks
> Mapped views of a file mapping object maintain internal references to the object, and a file mapping object does not close until all references to it are released. Therefore, to fully close a file mapping object, an application must unmap all mapped views of the file mapping object by calling UnmapViewOfFile and close the file mapping object handle by calling CloseHandle. These functions can be called in any order.

