### PR TITLE
Raise useful exceptions from python module

### DIFF
--- a/donutmodule.c
+++ b/donutmodule.c
@@ -166,8 +166,12 @@ static PyObject *Donut_Create(PyObject *self, PyObject *args, PyObject *keywds) 
 
     int err = DonutCreate(&c);
 
-    // printf("Error : %i\n", err); 
-    
+    if(err != DONUT_ERROR_SUCCESS) {
+        PyErr_SetString(PyExc_RuntimeError, DonutError(err));
+        DonutDelete(&c);
+        return NULL;
+    }
+
     PyObject *shellcode = Py_BuildValue("y#", c.pic, c.pic_len);
 
     DonutDelete(&c);


### PR DESCRIPTION
The Python module should raise an exception if `DonutCreate()` fails. And since we have `DonutError()`, we can even make that a useful error message