### PR TITLE
Fix "SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats" when using Python 3.10

### DIFF
--- a/donutmodule.c
+++ b/donutmodule.c
@@ -172,7 +172,7 @@ static PyObject *Donut_Create(PyObject *self, PyObject *args, PyObject *keywds) 
         return NULL;
     }
 
-    PyObject *shellcode = Py_BuildValue("y#", c.pic, c.pic_len);
+    PyObject *shellcode = PyBytes_FromStringAndSize(c.pic, c.pic_len);
 
     DonutDelete(&c);
 


### PR DESCRIPTION
Hi,
I found when importing the donut module in python 3.10 and creating shellcode, a system error is thrown.

```
$ pip freeze | grep donut-shellcode
donut-shellcode==0.9.2
$ python                           
Python 3.10.1 (main, Dec 18 2021, 23:53:45) [GCC 11.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import donut
>>> shellcode = donut.create(file='test.exe')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
>>>
```

Python 3.10 now requires the `PY_SSIZE_T_CLEAN` macro to be defined when using the `y#` format specifier for creating PyObjects. https://docs.python.org/3.10/whatsnew/3.10.html#id2

An alternative is the `PyBytes_FromStringAndSize` function which is supported in python 3.10 and provides the same functionality. https://docs.python.org/3/c-api/bytes.html#c.PyBytes_FromStringAndSize