### PR TITLE
Building MinGW32 + Clang 10 + wclang on Ubuntu 20.04

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -1,22 +1,28 @@
-CC32 := i686-w64-mingw32-gcc
-CC64 := x86_64-w64-mingw32-gcc
+# fix for `lld-link: error: undefined symbol: ___chkstk_ms`
+CFLAGS := -lgcc -flto
+
+CC32 := i686-w64-mingw32-clang $(CFLAGS)
+CC64 := x86_64-w64-mingw32-clang $(CFLAGS)
+CC   := x86_64-w64-mingw32-clang
 
 donut: clean
 	$(info ###### RELEASE ######)
 	gcc -I include loader/exe2h/exe2h.c -oexe2h
-	$(CC64) -I include loader/exe2h/exe2h.c loader/exe2h/mmap-windows.c -lshlwapi -oexe2h.exe
+	$(CC) -I include loader/exe2h/exe2h.c loader/exe2h/mmap-windows.c -lshlwapi -oexe2h.exe
 	
-	$(CC32) -DBYPASS_AMSI_A -DBYPASS_WLDP_A -fno-toplevel-reorder -fpack-struct=8 -fPIC -O0 -nostdlib loader/loader.c loader/depack.c loader/clib.c hash.c encrypt.c -I include -oloader.exe
+	$(CC32) -fuse-ld=lld -Wl,-e,DonutLoader -fno-builtin -ffreestanding -fno-builtin-memcpy -disable-simpilfy-libcalls -DBYPASS_AMSI_B -DBYPASS_WLDP_A -DBYPASS_ETW_B -fpack-struct=8 -Os -nostdlib loader/loader.c loader/depack.c loader/clib.c hash.c encrypt.c -I include -oloader.exe
 	./exe2h loader.exe
 	
-	$(CC64) -DBYPASS_AMSI_A -DBYPASS_WLDP_A -fno-toplevel-reorder -fpack-struct=8 -fPIC -O0 -nostdlib loader/loader.c loader/depack.c loader/clib.c hash.c encrypt.c -I include -oloader.exe
+	$(CC64) -fuse-ld=lld -Wl,-e,DonutLoader -fno-builtin -ffreestanding -fno-builtin-memcpy -disable-simpilfy-libcalls -DBYPASS_AMSI_B -DBYPASS_WLDP_A -DBYPASS_ETW_B -fpack-struct=8 -Os -nostdlib loader/loader.c loader/depack.c loader/clib.c hash.c encrypt.c -I include -oloader.exe
 	./exe2h loader.exe
 	
-	$(CC64) -Wall -fpack-struct=8 -DDONUT_EXE -I include donut.c hash.c encrypt.c format.c loader/clib.c lib/aplib64.lib -odonut.exe
+	$(CC) -fuse-ld=lld -Wall -fpack-struct=8 -DDONUT_EXE -I include donut.c hash.c encrypt.c format.c loader/clib.c lib/aplib64.lib -odonut.exe
+
 debug: clean
 	$(info ###### DEBUG ######)
-	$(CC32) -DCLIB -DBYPASS_AMSI_A -DBYPASS_WLDP_A -Wno-format -fpack-struct=8 -DDEBUG -I include loader/loader.c hash.c encrypt.c loader/depack.c loader/clib.c -oloader32.exe -lole32 -lshlwapi
-	$(CC64) -DCLIB -DBYPASS_AMSI_A -DBYPASS_WLDP_A -Wno-format -fpack-struct=8 -DDEBUG -I include loader/loader.c hash.c encrypt.c loader/depack.c loader/clib.c -oloader64.exe -lole32 -lshlwapi
-	$(CC64) -Wall -Wno-format -fpack-struct=8 -DDEBUG -DDONUT_EXE -I include donut.c hash.c encrypt.c format.c loader/clib.c lib/aplib64.lib -odonut.exe
+	$(CC32) -fuse-ld=lld -Wl,-e,DonutLoader -O2 -fno-builtin -ffreestanding -fno-builtin-memcpy -disable-simpilfy-libcalls -DCLIB -DBYPASS_AMSI_B -DBYPASS_WLDP_A -DBYPASS_ETW_B -Wno-format -fpack-struct=8 -DDEBUG -I include loader/loader.c hash.c encrypt.c loader/depack.c loader/clib.c -oloader32.exe -lole32 -lshlwapi
+	$(CC64) -fuse-ld=lld -Wl,-e,DonutLoader -O2 -fno-builtin -ffreestanding -fno-builtin-memcpy -disable-simpilfy-libcalls -DCLIB -DBYPASS_AMSI_B -DBYPASS_WLDP_A -DBYPASS_ETW_B -Wno-format -fpack-struct=8 -DDEBUG -I include loader/loader.c hash.c encrypt.c loader/depack.c loader/clib.c -oloader64.exe -lole32 -lshlwapi
+	$(CC) -fuse-ld=lld -Wall -Wno-format -fpack-struct=8 -DDEBUG -DDONUT_EXE -I include donut.c hash.c encrypt.c format.c loader/clib.c lib/aplib64.lib -odonut.exe
+
 clean:
 	rm -f exe2h exe2h.exe loader.bin instance donut.o hash.o encrypt.o format.o clib.o hash encrypt donut hash.exe encrypt.exe donut.exe lib/libdonut.a lib/libdonut.so loader.exe loader32.exe loader64.exe

--- a/loader/clib.c
+++ b/loader/clib.c
@@ -62,6 +62,14 @@ void *Memcpy (void *destination, const void *source, uint32_t num) {
     return destination;
 }
 
+void *memset (void *ptr, int value, uint32_t num) {
+  return Memset(ptr, value, num);
+}
+
+void *memcpy (void *destination, const void *source, uint32_t num) {
+  return Memcpy(destination, source, num);
+}
+
 int Memcmp(const void *ptr1, const void *ptr2, uint32_t num) {
     register const unsigned char *s1 = (const unsigned char*)ptr1;
     register const unsigned char *s2 = (const unsigned char*)ptr2;

--- a/loader/getpc.c
+++ b/loader/getpc.c
@@ -46,16 +46,17 @@
   #endif
 #elif defined(__GNUC__) 
   #if defined(__i386__)
-    asm (
-      ".global get_pc\n"
-      ".global _get_pc\n"
-      "_get_pc:\n"
-      "get_pc:\n"
-      "    call    pc_addr\n"
-      "pc_addr:\n"
-      "    pop     %eax\n"
-      "    sub     $5, %eax\n"
-      "    ret\n"
-    );
+  #ifndef DONUT_GETPC
+    #define DONUT_GETPC 1
+    volatile __declspec(naked) char *get_pc() {
+      asm (
+        "    call    pc_addr\n"
+        "pc_addr:\n"
+        "    pop     %eax\n"
+        "    sub     $5, %eax\n"
+        "    ret\n"
+      );
+    }
+    #endif
   #endif
 #endif

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -75,7 +75,7 @@
 
 #if defined(_M_IX86) || defined(__i386__)
 // return pointer to code in memory
-char *get_pc(void);
+volatile char *get_pc(void);
 
 // PC-relative addressing for x86 code. Similar to RVA2VA except using functions in payload
 #define ADR(type, addr) (type)(get_pc() - ((ULONG_PTR)&get_pc - (ULONG_PTR)addr))


### PR DESCRIPTION
These changes required to make `master` branch of donut compile using Clang 10 with Mingw32 under Ubuntu 20.04.

Things working for me:
- Compiling release version of donut and loader 32/64bit in Ubuntu 20.04 using clang+lld from LLVM 10 running under mingw32 and wclang
- Generating donut shellcode using `wine donut.exe -o shellcode.bin -b 1 -a 1 exec.exe`
- Both 32 and 64 shellcodes work

What doesn't work:
- AMSI bypass does NOT work - it crashes right now inside generated shellcode's loader
- Debug version of loader32.exe/loader64.exe fail to load debug instance - fails on "Resolving address of CreateThread"
- `dev` branch does not work with these changes for me