### PR TITLE
Fix circular includes

### DIFF
--- a/format.c
+++ b/format.c
@@ -31,6 +31,23 @@
 
 #include "format.h"
 
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "errors.h"
+
+// Add DPRINT macro from donut.h since it is needed but all of donut.h cannot be included
+#if defined(DEBUG)
+ #define DPRINT(...) { \
+   fprintf(stderr, "DEBUG: %s:%d:%s(): ", __FILE__, __LINE__, __FUNCTION__); \
+   fprintf(stderr, __VA_ARGS__); \
+   fprintf(stderr, "\n"); \
+ }
+#else
+ #define DPRINT(...) // Don't do anything in release builds
+#endif
+
+
 /**
   Encoding: base64
   Author  : Odzhan

--- a/include/donut.h
+++ b/include/donut.h
@@ -80,6 +80,7 @@
 
 #endif
 
+#include "errors.h"      // Donut errors
 #include "hash.h"        // api hashing
 #include "encrypt.h"     // symmetric encryption of instance+module
 #include "format.h"      // output format for loader
@@ -109,30 +110,6 @@ typedef struct _GUID {
 
 #define DONUT_KEY_LEN                    16
 #define DONUT_BLK_LEN                    16
-
-#define DONUT_ERROR_OK                   0
-#define DONUT_ERROR_FILE_NOT_FOUND       1
-#define DONUT_ERROR_FILE_EMPTY           2
-#define DONUT_ERROR_FILE_ACCESS          3
-#define DONUT_ERROR_FILE_INVALID         4
-#define DONUT_ERROR_NET_PARAMS           5
-#define DONUT_ERROR_NO_MEMORY            6
-#define DONUT_ERROR_INVALID_ARCH         7
-#define DONUT_ERROR_INVALID_URL          8
-#define DONUT_ERROR_URL_LENGTH           9
-#define DONUT_ERROR_INVALID_PARAMETER   10
-#define DONUT_ERROR_RANDOM              11
-#define DONUT_ERROR_DLL_FUNCTION        12
-#define DONUT_ERROR_ARCH_MISMATCH       13
-#define DONUT_ERROR_DLL_PARAM           14
-#define DONUT_ERROR_BYPASS_INVALID      15
-#define DONUT_ERROR_INVALID_FORMAT      16
-#define DONUT_ERROR_INVALID_ENGINE      17
-#define DONUT_ERROR_COMPRESSION         18
-#define DONUT_ERROR_INVALID_ENTROPY     19
-#define DONUT_ERROR_MIXED_ASSEMBLY      20
-#define DONUT_ERROR_HEADERS_INVALID     21
-#define DONUT_ERROR_DECOY_INVALID       22
 
 // target architecture
 #define DONUT_ARCH_ANY                  -1  // for vbs and js files

--- a/include/errors.h
+++ b/include/errors.h
@@ -29,29 +29,31 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef FORMAT_H
-#define FORMAT_H
+#ifndef ERRORS_H
+#define ERRORS_H
 
-#include <stdint.h>
-#include <stdio.h>
+#define DONUT_ERROR_OK                   0
+#define DONUT_ERROR_FILE_NOT_FOUND       1
+#define DONUT_ERROR_FILE_EMPTY           2
+#define DONUT_ERROR_FILE_ACCESS          3
+#define DONUT_ERROR_FILE_INVALID         4
+#define DONUT_ERROR_NET_PARAMS           5
+#define DONUT_ERROR_NO_MEMORY            6
+#define DONUT_ERROR_INVALID_ARCH         7
+#define DONUT_ERROR_INVALID_URL          8
+#define DONUT_ERROR_URL_LENGTH           9
+#define DONUT_ERROR_INVALID_PARAMETER   10
+#define DONUT_ERROR_RANDOM              11
+#define DONUT_ERROR_DLL_FUNCTION        12
+#define DONUT_ERROR_ARCH_MISMATCH       13
+#define DONUT_ERROR_DLL_PARAM           14
+#define DONUT_ERROR_BYPASS_INVALID      15
+#define DONUT_ERROR_INVALID_FORMAT      16
+#define DONUT_ERROR_INVALID_ENGINE      17
+#define DONUT_ERROR_COMPRESSION         18
+#define DONUT_ERROR_INVALID_ENTROPY     19
+#define DONUT_ERROR_MIXED_ASSEMBLY      20
+#define DONUT_ERROR_HEADERS_INVALID     21
+#define DONUT_ERROR_DECOY_INVALID       22
 
-#include "hash.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-int base64_template(void *pic, uint32_t pic_len, FILE *fd);
-int c_ruby_template(void *pic, uint32_t pic_len, FILE *fd);
-int py_template(void *pic, uint32_t pic_len, FILE* fd);
-int powershell_template(void *pic, uint32_t pic_len, FILE *fd);
-int csharp_template(void *pic, uint32_t pic_len, FILE *fd);
-int hex_template(void *pic, uint32_t pic_len, FILE *fd);
-int uuid_template(void *pic, uint32_t pic_len, FILE *fd);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif
-
+#endif // ERRORS_H


### PR DESCRIPTION
There is a circular include where [include/donut.h#L85](https://github.com/TheWover/donut/blob/85fdadec75225396c6ad322c882b4ecbc2124598/include/donut.h#L85) includes `format.h` while [include/format.h#L35](https://github.com/TheWover/donut/blob/85fdadec75225396c6ad322c882b4ecbc2124598/include/format.h#L35) includes `donut.h`. This could potentially cause issues where included symbols do not get defined.


Since `format.c` only uses `donut.h` for the error macros, they can be refactored out into a separate `errors.h` file which can be included separately in `format.c` without needing to include all of `donut.h`.

The `DPRINT` macro has to be re-implemented because it is needed for `format.c` but is only defined in `donut.h` and `loader/loader.h`. [loader/loader.h#L101](https://github.com/TheWover/donut/blob/85fdadec75225396c6ad322c882b4ecbc2124598/loader/loader.h#L101) also includes `donut.h` so it cannot be used since this would result in another circular include.