### PR TITLE
Fix mingw gcc builds

### DIFF
--- a/loader/bypass.h
+++ b/loader/bypass.h
@@ -34,6 +34,10 @@
 
 //#include <ntstatus.h>
 
+#include "winapi.h" // Needed for the *_t function prototypes used in donut.h `DONUT_INSTANCE`
+
+#include "donut.h"
+
 // Disables Antimalware Scan Interface
 BOOL DisableAMSI(PDONUT_INSTANCE);
 

--- a/loader/peb.h
+++ b/loader/peb.h
@@ -210,14 +210,6 @@ typedef struct _TEB_ACTIVE_FRAME
     PTEB_ACTIVE_FRAME_CONTEXT Context;
 } TEB_ACTIVE_FRAME, *PTEB_ACTIVE_FRAME;
 
-#if !defined(_MSC_VER)
-typedef struct _PROCESSOR_NUMBER {
-  USHORT Group;
-  UCHAR  Number;
-  UCHAR  Reserved;
-} PROCESSOR_NUMBER, *PPROCESSOR_NUMBER;
-#endif
-
 typedef struct _TEB
 {
     NT_TIB NtTib;

--- a/loader/winapi.h
+++ b/loader/winapi.h
@@ -33,7 +33,6 @@
 #define WINAPI_H
 
 #include <windows.h>
-#include "bypass.h" //For the structs necessary for each bypass
 
     typedef LPVOID (WINAPI *HeapAlloc_t)(
       HANDLE hHeap,


### PR DESCRIPTION
I noticed some issues when trying to build Donut using mingw
```bash
$ make -f Makefile.mingw
rm -f exe2h exe2h.exe loader.bin instance donut.o hash.o encrypt.o format.o clib.o hash encrypt donut hash.exe encrypt.exe donut.exe lib/libdonut.a lib/libdonut.so loader.exe loader32.exe loader64.exe inject32.exe inject64.exe inject_local32.exe inject_local64.exe
###### RELEASE ######
gcc -I include loader/exe2h/exe2h.c -oexe2h
x86_64-w64-mingw32-gcc -I include loader/exe2h/exe2h.c loader/exe2h/mmap-windows.c -lshlwapi -oexe2h.exe
i686-w64-mingw32-gcc -DBYPASS_AMSI_B -DBYPASS_WLDP_A -DBYPASS_ETW_B -fno-toplevel-reorder -fpack-struct=8 -fPIC -O0 -nostdlib loader/loader.c loader/depack.c loader/clib.c hash.c encrypt.c -I include -oloader.exe
In file included from loader/loader.h:97,
                 from loader/loader.c:32:
loader/peb.h:214:16: error: redefinition of 'struct _PROCESSOR_NUMBER'
  214 | typedef struct _PROCESSOR_NUMBER {
      |                ^~~~~~~~~~~~~~~~~
In file included from /usr/i686-w64-mingw32/sys-root/mingw/include/minwindef.h:163,
                 from /usr/i686-w64-mingw32/sys-root/mingw/include/windef.h:9,
                 from /usr/i686-w64-mingw32/sys-root/mingw/include/windows.h:69,
                 from loader/loader.h:41:
/usr/i686-w64-mingw32/sys-root/mingw/include/winnt.h:10354:16: note: originally defined here
10354 | typedef struct _PROCESSOR_NUMBER {
      |                ^~~~~~~~~~~~~~~~~
loader/peb.h:218:3: error: conflicting types for 'PROCESSOR_NUMBER'; have 'struct _PROCESSOR_NUMBER'
  218 | } PROCESSOR_NUMBER, *PPROCESSOR_NUMBER;
      |   ^~~~~~~~~~~~~~~~
/usr/i686-w64-mingw32/sys-root/mingw/include/winnt.h:10358:3: note: previous declaration of 'PROCESSOR_NUMBER' with type 'PROCESSOR_NUMBER'
10358 | } PROCESSOR_NUMBER, *PPROCESSOR_NUMBER;
      |   ^~~~~~~~~~~~~~~~
loader/peb.h:218:22: error: conflicting types for 'PPROCESSOR_NUMBER'; have 'struct _PROCESSOR_NUMBER *'
  218 | } PROCESSOR_NUMBER, *PPROCESSOR_NUMBER;
      |                      ^~~~~~~~~~~~~~~~~
/usr/i686-w64-mingw32/sys-root/mingw/include/winnt.h:10358:22: note: previous declaration of 'PPROCESSOR_NUMBER' with type 'PPROCESSOR_NUMBER' {aka 'struct _PROCESSOR_NUMBER *'}
10358 | } PROCESSOR_NUMBER, *PPROCESSOR_NUMBER;
      |                      ^~~~~~~~~~~~~~~~~
In file included from loader/winapi.h:36,
                 from loader/loader.h:98:
loader/bypass.h:38:1: error: parameter names (without types) in function declaration [-Wdeclaration-missing-parameter-type]
   38 | BOOL DisableAMSI(PDONUT_INSTANCE);
      | ^~~~
loader/bypass.h:41:1: error: parameter names (without types) in function declaration [-Wdeclaration-missing-parameter-type]
   41 | BOOL DisableWLDP(PDONUT_INSTANCE);
      | ^~~~
loader/bypass.h:44:1: error: parameter names (without types) in function declaration [-Wdeclaration-missing-parameter-type]
   44 | BOOL DisableETW(PDONUT_INSTANCE);
      | ^~~~
In file included from loader/loader.c:385:
loader/inmem_pe.c: In function 'RunPE':
loader/inmem_pe.c:229:39: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  229 |     ntnew->OptionalHeader.ImageBase = (ULONGLONG)cs;
      |                                       ^
make: *** [Makefile.mingw:9: donut] Error 1
```

The first issue is with the `_PROCESSOR_NUMBER` structure redefinition in [`loader/peb.h#L214`](https://github.com/TheWover/donut/blob/85fdadec75225396c6ad322c882b4ecbc2124598/loader/peb.h#L214). This header is importing `windows.h` which, in turn, includes `winnt.h` where this structure is defined. The structure definition in the Windows API matches this one defined here so it should be okay to use that one instead of redefining it here. This header file is only included when building for Windows so that symbol should always exist.


The other issue is due to the missing Windows type definitions and `PDONUT_INSTANCE` symbol in [`loader/bypass.h#L38`](https://github.com/TheWover/donut/blob/85fdadec75225396c6ad322c882b4ecbc2124598/loader/bypass.h#L38). Including `donut.h` to get the `PDONUT_INSTANCE` structure definition, leads to some other issues with `donut.h`. The type definitions for the redefined Windows API types with the `*_t` suffix are being transitively included in `donut.h` so they need to be included before including `donut.h`.


These changes should fix the builds for mingw.