### PR TITLE
Cast `Donut_Create` to `PyCFunction`

### DIFF
--- a/donutmodule.c
+++ b/donutmodule.c
@@ -196,7 +196,15 @@ static PyObject *Donut_Create(PyObject *self, PyObject *args, PyObject *keywds) 
 static PyMethodDef Donut_FunctionsTable[] = {
     {
         "create", // name exposed to Python
-        Donut_Create, // C wrapper function
+        // Note that this struct member _must_ be of type PyCFunction,
+        // even if (as in this case) it is secretly of type
+        // PyCFunctionWithKeywords.  This is the reason for the cast;
+        // gcc errors out without it.
+        //
+        // This is all specified in the description of the ml_meth
+        // struct member in this piece of the Python documentation:
+        // https://docs.python.org/3.12/c-api/structures.html#c.PyMethodDef
+        (PyCFunction) Donut_Create, // C wrapper function
         METH_VARARGS|METH_KEYWORDS,
         "Calls DonutCreate to generate shellcode for a .NET assembly" // documentation
     }, 


### PR DESCRIPTION
When rebuilding an AMI using the latest Kali base AMI, I found that the `donut` Python extension [failed to build](https://github.com/cisagov/kali-packer/actions/runs/10853868968/job/30123604382#step:16:4564) with the following output:
```console
❯ pip install .
Processing /home/jeremy_frasier/TheWover/donut
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: donut-shellcode
  Building wheel for donut-shellcode (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Building wheel for donut-shellcode (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [46 lines of output]
      running bdist_wheel
      running build
      running build_ext
      building 'donut' extension
      gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -Iinclude -I/home/jeremy_frasier/.pyenv/versions/3.12.6/envs/donut/include -I/home/jeremy_frasier/.pyenv/versions/3.12.6/include/python3.12 -c donut.c -o build/temp.linux-x86_64-cpython-312/donut.o
      donut.c: In function ‘read_file_info’:
      donut.c:574:19: warning: comparison of integer expressions of different signedness: ‘ULONG64’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
        574 |           if (ofs != -1) {
            |                   ^~
      donut.c:579:22: warning: comparison of integer expressions of different signedness: ‘ULONG64’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
        579 |               if(ofs != -1) {
            |                      ^~
      donut.c: In function ‘gen_random_string’:
      donut.c:667:15: warning: comparison of integer expressions of different signedness: ‘int’ and ‘uint64_t’ {aka ‘long unsigned int’} [-Wsign-compare]
        667 |     for(i=0; i<len; i++) {
            |               ^
      donut.c: In function ‘is_dll_export’:
      donut.c:1487:16: warning: comparison of integer expressions of different signedness: ‘ULONG64’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
       1487 |         if(ofs != -1) {
            |                ^~
      In function ‘build_module’,
          inlined from ‘DonutCreate’ at donut.c:1596:17:
      donut.c:768:7: warning: ‘strncpy’ output may be truncated copying 255 bytes from a string of length 255 [-Wstringop-truncation]
        768 |       strncpy(mod->method, c->method, DONUT_MAX_NAME-1);
            |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      donut.c:746:9: warning: ‘strncpy’ output may be truncated copying 8 bytes from a string of length 255 [-Wstringop-truncation]
        746 |         strncpy(mod->domain, c->domain, DONUT_DOMAIN_LEN);
            |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      donut.c:753:9: warning: ‘strncpy’ output may be truncated copying 255 bytes from a string of length 255 [-Wstringop-truncation]
        753 |         strncpy(mod->cls, c->cls, DONUT_MAX_NAME-1);
            |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      donut.c:756:9: warning: ‘strncpy’ output may be truncated copying 255 bytes from a string of length 255 [-Wstringop-truncation]
        756 |         strncpy(mod->method, c->method, DONUT_MAX_NAME-1);
            |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      donut.c:763:7: warning: ‘strncpy’ output may be truncated copying 255 bytes from a string of length 255 [-Wstringop-truncation]
        763 |       strncpy(mod->runtime, c->runtime, DONUT_MAX_NAME-1);
            |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      donut.c:792:7: warning: ‘strncat’ output may be truncated copying 250 bytes from a string of length 255 [-Wstringop-truncation]
        792 |       strncat(mod->args, c->args, DONUT_MAX_NAME-6);
            |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -Iinclude -I/home/jeremy_frasier/.pyenv/versions/3.12.6/envs/donut/include -I/home/jeremy_frasier/.pyenv/versions/3.12.6/include/python3.12 -c donutmodule.c -o build/temp.linux-x86_64-cpython-312/donutmodule.o
      donutmodule.c:199:9: error: initialization of ‘PyObject * (*)(PyObject *, PyObject *)’ {aka ‘struct _object * (*)(struct _object *, struct _object *)’} from incompatible pointer type ‘PyObject * (*)(PyObject *, PyObject *, PyObject *)’ {aka ‘struct _object * (*)(struct _object *, struct _object *, struct _object *)’} [-Wincompatible-pointer-types]
        199 |         Donut_Create, // C wrapper function
            |         ^~~~~~~~~~~~
      donutmodule.c:199:9: note: (near initialization for ‘Donut_FunctionsTable[0].ml_meth’)
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for donut-shellcode
Failed to build donut-shellcode
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (donut-shellcode)
```

Digging into the code, I found the reason to be that the [`ml_meth` member of the `PyMethodDef` struct _must_ be of type `PyCFunction`](https://docs.python.org/3.12/c-api/structures.html#c.PyMethodDef), even if it is secretly of type `PyCFunctionWithKeywords`, `PyCMethod`, etc.  This is why the cast I added is necessary; `gcc` errors out without it - at least with the 14.2.0 version of `gcc` that is currently offered on Kali.

I confirmed that adding the cast made the Python extension build again.
