### PR TITLE
Fix 1-byte buffer overflow in DONUT_INSTANCE.etwRet64

### DIFF
--- a/include/donut.h
+++ b/include/donut.h
@@ -369,7 +369,7 @@ typedef struct _DONUT_INSTANCE {
     char        amsiScanStr[16];              // AmsiScanString
     char        etwEventWrite[16];            // EtwEventWrite
     char        etwEventUnregister[20];       // EtwEventUnregister
-    char        etwRet64[1];                  // "ret" instruction for Etw
+    char        etwRet64[2];                  // "ret" instruction for Etw
     char        etwRet32[4];                  // "ret 14h" instruction for Etw
     
     char        wscript[8];                   // WScript


### PR DESCRIPTION
## Summary

Fixes a buffer overflow in `include/donut.h` where `etwRet64` is declared as a 1-byte array but `strcpy` in `donut.c:983` writes 2 bytes (the `\xc3` byte plus null terminator).

## The Bug

```c
// include/donut.h:372
char etwRet64[1];  // 1 byte

// donut.c:983
strcpy(inst->etwRet64, "\xc3");  // Writes 2 bytes
```

This causes a 1-byte overflow into the adjacent etwRet32 field. On most Linux systems this goes unnoticed because etwRet32 is immediately overwritten afterward, but platforms with fortified libc (macOS, some hardened Linux distributions) detect this at runtime and abort.

## The Fix
Change the buffer size from 1 to 2 bytes to accommodate the null terminator.

## Impact
 - Linux: Silent memory corruption (no immediate crash, data gets overwritten anyway)
 - macOS/hardened systems: Crashes with SIGILL (__chk_fail_overflow triggers ud2)

## Testing
Verified the fix allows successful shellcode generation on macOS where it previously crashed.
